### PR TITLE
Fix md of btn-wp

### DIFF
--- a/style.css
+++ b/style.css
@@ -211,7 +211,9 @@ body {
   .btn-how-it-works {
     margin-top: 10vh;
   }
+}
 
+@media (max-width: 991px) {
   .btn-wp {
     margin-left: 0px;
   }


### PR DESCRIPTION
**What's done?**

Removes the margin-left of _.btn-wp_ on _md_ view to prevent page overflowing.

**Why 991px?**

Follow [responsive breakpoints Bootstrap standard](https://v4-alpha.getbootstrap.com/layout/overview/#responsive-breakpoints).